### PR TITLE
feat(cli): Purge command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7,6 +7,7 @@ use crate::generate;
 mod refresh;
 mod install;
 mod config;
+mod purge;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -21,7 +22,9 @@ pub enum Error {
     #[error("generation failed: {0}")]
     Generate(#[from] generate::GenerateError),
     #[error("invalid argument(s): {0}")]
-    ArgMatch(#[from] clap::Error)
+    ArgMatch(#[from] clap::Error),
+    #[error("{0}")]
+    ConfirmationNeeded(String)
 
 }
 impl From<std::io::Error> for Error {
@@ -61,6 +64,7 @@ pub fn all_commands() -> HashMap<String, CommandAndRunner> {
     return collection!{
         config::NAME => config::command(),
         refresh::NAME => refresh::command(),
-        install::NAME => install::command()
+        install::NAME => install::command(),
+        purge::NAME => purge::command()
     };
 }

--- a/cli/src/commands/purge.rs
+++ b/cli/src/commands/purge.rs
@@ -1,0 +1,108 @@
+use clap::{arg, ArgAction, Command, command, Subcommand, value_parser, ValueEnum};
+use fontpm_api::{info, ok, error};
+use tokio::task::JoinSet;
+use crate::commands::{CommandAndRunner, Error};
+use crate::config::FpmConfig;
+use crate::host_impl::FpmHostImpl;
+use crate::runner;
+
+pub const NAME: &str = "purge";
+
+#[derive(ValueEnum, Clone)]
+#[value(rename_all = "kebab-case")]
+enum PurgeTarget {
+    Cache,
+    #[value(alias = "fonts")]
+    InstalledFonts,
+    All
+}
+
+const SUFFIX: &str = "This action is irrevocable. (Run this command with --confirm)";
+
+async fn purge(target: PurgeTarget, config: FpmConfig) -> Result<String, Error> {
+    match target {
+        PurgeTarget::Cache => {
+            let dir = config.cache_dir();
+            if dir.exists() {
+                info!("Purging cache...");
+                tokio::fs::remove_dir_all(dir).await?;
+                Ok("Purged cache.".to_string())
+            } else {
+                Ok("Cache already purged.".to_string())
+            }
+        },
+        PurgeTarget::InstalledFonts => {
+            let dir = config.font_install_dir();
+            if dir.exists() {
+                info!("Purging installed fonts - you will need to reinstall any fonts you've already installed.");
+                tokio::fs::remove_dir_all(dir).await?;
+                Ok("Purged installed fonts. You will need to reinstall all fonts you've already installed.".to_string())
+            } else {
+                Ok("All installed fonts have already been deleted.".to_string())
+            }
+        },
+        PurgeTarget::All => {
+            panic!("purge can not be called with target All");
+        }
+    }
+}
+
+runner! { args =>
+    let confirm = args.get_flag("confirm");
+    let target: &PurgeTarget = args.get_one("target").unwrap();
+    if !confirm {
+        return Err(Error::ConfirmationNeeded(format!("{} {}", match target {
+            PurgeTarget::Cache => "Are you sure you want to purge the cache?",
+            PurgeTarget::InstalledFonts => "Are you sure you want to purge all FontPM-installed fonts?",
+            PurgeTarget::All => "Are you sure you want to purge all FontPM data?"
+        }, SUFFIX)))
+    }
+    let config = FpmConfig::load()?;
+    let mut tasks = JoinSet::new();
+    match target {
+        PurgeTarget::All => {
+            tasks.spawn(purge(PurgeTarget::Cache, config.clone()));
+            tasks.spawn(purge(PurgeTarget::Cache, config));
+        },
+        other => {
+            tasks.spawn(purge(other.clone(), config));
+        }
+    }
+
+    let mut command_result = Ok(None);
+    while let Some(result) = tasks.join_next().await {
+        let result = match result {
+            Ok(result) => result,
+            Err(e) => {
+                error!("Could not join task: {}", e);
+                continue
+            }
+        };
+        match result {
+            Ok(message) => {
+                ok!("{}", message);
+            },
+            Err(e) => {
+                command_result = Err(e);
+            }
+        }
+    }
+
+    command_result
+}
+
+pub fn command() -> CommandAndRunner {
+    let command = Command::new(NAME)
+        .about("Purges all of FontPM's cached files.")
+        .args(vec![
+            arg!([target] "What to purge. Can be either 'cache', 'fonts', or 'all'")
+                .value_parser(value_parser!(PurgeTarget))
+                .default_value("all"),
+            arg!(-c --confirm "Confirms that you want to.")
+                .action(ArgAction::SetTrue)
+        ]);
+    return CommandAndRunner {
+        description: command,
+        runner: Box::new(runner)
+    };
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,8 +13,8 @@ extern crate async_trait;
 
 use clap::{arg, ArgAction, Command};
 use clap::parser::ValueSource;
-use fontpm_api::{error, ok};
-use crate::commands::all_commands;
+use fontpm_api::{error, ok, warning};
+use crate::commands::{all_commands, Error};
 use crate::output_impl::OutputLevel;
 
 pub const VERSION_STR: &str = env!("CARGO_PKG_VERSION");
@@ -80,8 +80,13 @@ async fn main() {
                     ok!("{}", message);
                 }
             },
-            Err(e) => {
-                error!("{}", e);
+            Err(e) => match e {
+                Error::ConfirmationNeeded(message) => {
+                    warning!("Confirmation needed: {}", message);
+                }
+                e => {
+                    error!("{}", e);
+                }
             }
         }
     } else {


### PR DESCRIPTION
Adds the `purge` command.

Description from clap:
```
Purges all of FontPM's cached files.

Usage: fontpm purge [OPTIONS] [target]

Arguments:
  [target]  What to purge. Can be either 'cache', 'fonts', or 'all' [default: all] [possible values: cache, installed-fonts, all]

Options:
  -c, --confirm     Confirms that you want to.
  -s, --silent...   Silent output - will only print errors
  -v, --verbose...  Verbose output - will print all messages. May be repeated.
  -h, --help        Print help
````